### PR TITLE
Fix cron schedule entry

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -150,7 +150,7 @@ function cron_config() {
       # default value
 
       if [ -z "${CRON_SCHEDULE}" ]; then
-        export CRON_SCHEDULE='0 24 * * *'
+        export CRON_SCHEDULE='0 0 * * *'
       fi
       envsubst < /build_data/backups-cron > /backup-scripts/backups-cron
 


### PR DESCRIPTION
As per issue #108, scripts/start.sh needs a fix so that the crontab entry can be added and the backup script runs at midnight. The hours value needs to be 0 rather than 24.